### PR TITLE
Swap firstname and lastname retrieval from CommonName

### DIFF
--- a/internal/utils/certificate.go
+++ b/internal/utils/certificate.go
@@ -36,8 +36,8 @@ func Extract(encodedCert string) (*Person, error) {
 	if err != nil {
 		return nil, err
 	}
-	firstName := strings.TrimSpace(parts[0])
-	lastName := strings.TrimSpace(parts[1])
+	firstName := strings.TrimSpace(parts[1])
+	lastName := strings.TrimSpace(parts[0])
 
 	return &Person{
 		IdentityNumber: cert.Subject.SerialNumber,


### PR DESCRIPTION
SmartID demo account 040404-19999 has firstname "Ok", lastname "TESTNUMBER" in smartid demo login page and dokobit documentation
<img width="2135" height="547" alt="Ekrānuzņēmums 2025-07-23 120941" src="https://github.com/user-attachments/assets/b45cc014-0a9c-4bf8-8bf8-ef9ea18ac1a7" />

Using the library resulted in name and surname being swapped in integrations. Log debugging certificate parsing as is revealed the swap -
<img width="573" height="493" alt="Ekrānuzņēmums 2025-07-23 121533" src="https://github.com/user-attachments/assets/ed0530cd-21eb-47fe-a91f-b28634e94146" />
<img width="382" height="88" alt="Ekrānuzņēmums 2025-07-23 121524" src="https://github.com/user-attachments/assets/007618b9-904c-48e2-80d0-fa4b39c08e04" />
